### PR TITLE
Fix invalid config key in .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,6 +9,7 @@ build:
   os: ubuntu-20.04
   tools:
     python: "3.10"
+  system_packages: true
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
@@ -22,4 +23,3 @@ sphinx:
 python:
    install:
    - requirements: requirements.txt
-   system_packages: true


### PR DESCRIPTION
Fix Read the Docs build: move system_packages to correct section